### PR TITLE
add top nav bar using Material UI

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -1,19 +1,45 @@
 import React from "react";
+// import Button from "@material-ui/core/Button";
+
+import { makeStyles } from "@material-ui/core/styles";
+import AppBar from "@material-ui/core/AppBar";
+import Toolbar from "@material-ui/core/Toolbar";
+import Typography from "@material-ui/core/Typography";
+
+//import { ReactComponent as Logo } from "./static/images/goodtelly-logo.svg"
+// func useStyles 
+const useStyles = makeStyles((theme) => ({
+  appBar: {
+    backgroundColor: theme.palette.common.white,
+  },
+  toolBar: {
+    minHeight: 72,
+  },
+  navTitle: {
+    color: theme.palette.text.secondary,
+    marginRight: theme.spacing(2),
+  },
+  logo: {
+    margin: `0px ${theme.spacing(2)}px`,
+  },
+}));
 
 function Header() {
+  const classes = useStyles();
   return (
-    <main>
-      <h1
-        style={{
-          fontWeight: 200,
-          fontSize: "3em",
-          textAlign: "center",
-        }}
-      >
-        My React App
-      </h1>
-
-    </main>
+    <header>
+      <AppBar position="static" className={classes.appBar}>
+        <Toolbar className="classes.toolBar">
+          <div className={classes.logo}>{/* <Logo /> */}</div>
+          <Typography variant="h6" className={classes.navTitle}>
+            Movies
+          </Typography>
+          <Typography variant="h6" className={classes.navTitle}>
+            TV shows
+          </Typography>
+        </Toolbar>
+      </AppBar>
+    </header>
   );
 }
 


### PR DESCRIPTION
For [ticket](https://trello.com/c/LUVcJpnP/31-create-the-top-navigation-with-the-good-telly-logo-and-movies-and-tv-shows-links)

Add top Nav (without SVG Logo):

![Screenshot 2020-10-14 at 17 24 20](https://user-images.githubusercontent.com/52823456/96017771-4c8ef600-0e42-11eb-9d05-191549267b2a.png)
